### PR TITLE
fix typo in controller name

### DIFF
--- a/src/controllers/oracle.ts
+++ b/src/controllers/oracle.ts
@@ -27,7 +27,7 @@ export type OracleInfo = {
 
 @Route('oracle')
 @Tags('Oracle')
-export default class OralceController {
+export default class OracleController {
   constructor(
     private keyPair: ECPairInterface,
     private availableTickers: string[],

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import OralceController from '../controllers/oracle';
+import OracleController from '../controllers/oracle';
 import PingController from '../controllers/ping';
 
 import { ECPairInterface } from 'ecpair';
@@ -18,13 +18,13 @@ export default function routerFactory(
   });
 
   router.get('/oracle', (_req, res) => {
-    const controller = new OralceController(keyPair, availableTickers, url);
+    const controller = new OracleController(keyPair, availableTickers, url);
     const response = controller.getInfo();
     return res.send(response);
   });
 
   router.get('/oracle/:ticker', async (req, res) => {
-    const controller = new OralceController(keyPair, availableTickers, url);
+    const controller = new OracleController(keyPair, availableTickers, url);
     try {
       const response = await controller.getAttestationForTicker(
         req.params.ticker,


### PR DESCRIPTION
From `OralceController` to `OracleController`

@miyo-fuji please review