### PR TITLE
fix bug where message returned on bitfinex downtime was [object, object]

### DIFF
--- a/src/utils/axiosError.ts
+++ b/src/utils/axiosError.ts
@@ -15,10 +15,7 @@ export function extractErrorMessage(
   if (typeof error === 'string') return error;
 
   // since AxiosError is an instance of Error, this should come first
-  if (axios.isAxiosError(error)) {
-    if (error.response) return error.response.data;
-    if (error.request) return error.request.data;
-  }
+  if (axios.isAxiosError(error)) return error.message;
 
   // this should be last
   if (error instanceof Error) return error.message;


### PR DESCRIPTION
both error.response.data and error.request.data are objects,
so returning this would make message be [object, object]

we have a string on axiosError we can use, error.message

@miyo-fuji please review