### PR TITLE
Add `apicache` on `/oracle/:ticker` route

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format": "npx prettier --ignore-path .gitignore --write \"**/*.+(ts)\""
   },
   "devDependencies": {
+    "@types/apicache": "^1.6.2",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/jest": "^28.1.3",
@@ -40,6 +41,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "apicache": "^1.6.3",
     "axios": "^0.27.2",
     "axios-request-throttle": "^1.0.0",
     "cors": "^2.8.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import { CoingeckoPriceSource } from './ports/coingecko';
 import { KrakenPriceSource } from './ports/kraken';
 import { OkxPriceSource } from './ports/okx';
 import { BinancePriceSource } from './ports/binance';
+import OracleController from './controllers/oracle';
+import PingController from './controllers/ping';
 
 // ENV vars
 const PORT = process.env.PORT || 8000;
@@ -39,10 +41,13 @@ const oracle = ECPair.fromPrivateKey(Buffer.from(PRIVATE_KEY, 'hex'));
 const app: Application = express();
 
 const router = routerFactory(
-  oracle,
-  [Ticker.BTCUSD],
-  new PriceSourceManager(sources, console.error),
-  IS_DEVELOPMENT
+  new OracleController(
+    oracle,
+    [Ticker.BTCUSD],
+    new PriceSourceManager(sources, console.error),
+    IS_DEVELOPMENT
+  ),
+  new PingController()
 );
 
 app.use(express.json());

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,57 +1,48 @@
 import express from 'express';
+import apicache from 'apicache';
 import OracleController from '../controllers/oracle';
 import PingController from '../controllers/ping';
 
-import { ECPairInterface } from 'ecpair';
-import { PriceSource } from '../domain/price-source';
+const CACHE_DURATION = '30 seconds';
 
 export default function routerFactory(
-  keyPair: ECPairInterface,
-  availableTickers: string[],
-  priceSource: PriceSource,
-  isDevelopment = false
+  oracleController: OracleController,
+  pingController: PingController
 ) {
   const router = express.Router();
 
   router.get('/ping', async (_req, res) => {
-    const controller = new PingController();
-    const response = await controller.getMessage();
+    const response = await pingController.getMessage();
     return res.send(response);
   });
 
   router.get('/oracle', (_req, res) => {
-    const controller = new OracleController(
-      keyPair,
-      availableTickers,
-      priceSource,
-      isDevelopment
-    );
-    const response = controller.getInfo();
+    const response = oracleController.getInfo();
     return res.send(response);
   });
 
-  router.get('/oracle/:ticker', async (req, res) => {
-    const controller = new OracleController(
-      keyPair,
-      availableTickers,
-      priceSource
-    );
-    try {
-      const response = await controller.getAttestationForTicker(
-        req.params.ticker,
-        req.query.timestamp as string,
-        req.query.lastPrice as string
-      );
-      if (!response)
-        return res.status(404).send({
-          message: `no attestation available for ticker ${req.params.ticker}`,
-        });
-      return res.send(response);
-    } catch (err: any) {
-      const message = err instanceof Error ? err.message : JSON.stringify(err);
-      return res.status(500).send({ message });
+  router.get(
+    '/oracle/:ticker',
+    apicache.middleware(CACHE_DURATION),
+    async (req, res) => {
+      try {
+        const response = await oracleController.getAttestationForTicker(
+          req.params.ticker,
+          req.query.timestamp as string,
+          req.query.lastPrice as string
+        );
+        if (!response)
+          return res.status(404).send({
+            message: `no attestation available for ticker ${req.params.ticker}`,
+          });
+        return res.send(response);
+      } catch (err: any) {
+        const message =
+          err instanceof Error ? err.message : JSON.stringify(err);
+        return res.status(500).send({ message });
+      }
     }
-  });
+  );
 
   return router;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,6 +675,14 @@
     reflect-metadata "^0.1.13"
     validator "^13.6.0"
 
+"@types/apicache@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@types/apicache/-/apicache-1.6.2.tgz#6517f16f55bdbeafd4915d38706df19485ab3240"
+  integrity sha512-V9oFTVCQv3/7kIwghDfdSEll1o27tgzGaBT7w184EEORV+lqWg+eknhS1ZTuM2RYcLjPFSvuoUbDj/CJLJuSOw==
+  dependencies:
+    "@types/express" "*"
+    "@types/redis" "^2.8.0"
+
 "@types/axios@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
@@ -831,6 +839,13 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/redis@^2.8.0":
+  version "2.8.32"
+  resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.32.tgz#1d3430219afbee10f8cfa389dad2571a05ecfb11"
+  integrity sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==
+  dependencies:
+    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.13.10"
@@ -1028,6 +1043,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+apicache@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/apicache/-/apicache-1.6.3.tgz#4441aa40f2a48c9dd6f11c73be937d563405355b"
+  integrity sha512-jS3VfUFpQ9BesFQZcdd1vVYg3ZsO2kGPmTJHqycIYPAQs54r74CRiyj8DuzJpwzLwIfCBYzh4dy9Jt8xYbo27w==
 
 append-field@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**This PR adds a route caching system on `oracle/:ticker`**

- [apicache](https://www.npmjs.com/package/apicache) keeps the signed message returned by `/oracle/:ticker` in memory during 30 seconds
- speed up the response time while the oracle is "spammed" (craft msg ~ 4000ms, returns cached value ~1ms)

it closes #20 

@tiero please review 