### PR TITLE
[FIX] Binance public URL + error handler improvements

### DIFF
--- a/src/domain/price-source.ts
+++ b/src/domain/price-source.ts
@@ -23,13 +23,13 @@ export class PriceSourceManager implements PriceSource {
   private bannedSources: { source: PriceSource; freeAt: number }[] = [];
 
   constructor(
-    private priceSources: PriceSource[],
+    public priceSources: PriceSource[],
     private errorHandler: (err: unknown) => void,
     private banTimeMs = PriceSourceManager.BAN_TIME_MS
   ) {}
 
   async getPrice(ticker: Ticker): Promise<number> {
-    await this.freeBannedSources();
+    this.freeBannedSources();
 
     if (this.priceSources.length === 0) {
       throw new Error('No price source available');
@@ -59,7 +59,7 @@ export class PriceSourceManager implements PriceSource {
   }
 
   private deletePriceSource(index: number) {
-    this.priceSources.splice(index, 1);
+    this.priceSources = this.priceSources.filter((_, i) => i !== index);
   }
 
   private ban(source: PriceSource) {
@@ -69,7 +69,7 @@ export class PriceSourceManager implements PriceSource {
     });
   }
 
-  private async freeBannedSources() {
+  private freeBannedSources() {
     const now = Date.now();
     this.bannedSources = this.bannedSources.filter(({ freeAt, source }) => {
       if (freeAt < now) {

--- a/src/ports/binance.ts
+++ b/src/ports/binance.ts
@@ -29,7 +29,7 @@ function toBinanceSymbol(ticker: Ticker): string {
 }
 
 export class BinancePriceSource implements PriceSource {
-  static URL = 'https://data.binance.com/api/v3/ticker/24hr';
+  static URL = 'https://api.binance.com/api/v3/ticker/24hr';
 
   async getPrice(ticker: Ticker): Promise<number> {
     const symbol = toBinanceSymbol(ticker);
@@ -39,7 +39,7 @@ export class BinancePriceSource implements PriceSource {
 
     if (!isBinanceResponse(response.data)) {
       throw new Error(
-        `Invalid response from ${BinancePriceSource.URL}/${ticker}`
+        `Invalid response from ${BinancePriceSource.URL}?symbol=${ticker}`
       );
     }
 

--- a/test/integration/price-source.test.ts
+++ b/test/integration/price-source.test.ts
@@ -82,6 +82,8 @@ describe('PriceSourceManager', () => {
       banTime
     );
 
+    expect(priceSource.priceSources.length).toBe(3);
+
     const firstCall = await priceSource.getPrice(Ticker.BTCUSD);
     expect(firstCall).toBe(200);
     expect(errHandler).toHaveBeenCalledTimes(1);
@@ -90,6 +92,7 @@ describe('PriceSourceManager', () => {
     expect(secondCall).toBe(200);
     // should not call errHandler again (banned for 1 minute)
     expect(errHandler).toHaveBeenCalledTimes(1);
+    expect(priceSource.priceSources.length).toBe(2);
 
     // wait banTime + 1 second
     await new Promise((resolve) => setTimeout(resolve, banTime));


### PR DESCRIPTION
TL;DR

1. `data.binance.com` ---> `api.binance.com`
2. do not use `splice` to remove banned price sources, it prevents `cannot read "getPrice" from undefined` error.
3. enrich `PriceSourceManager` testing.

@tiero @bordalix please review